### PR TITLE
Split config into simple and advanced

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ INSTALL_STAMP := .venv/.install.stamp
 ifndef POETRY_ACTIVE 
     $(warning Tip: Activate a poetry shell to run makefile targets faster: around 1 second per command) 
     CMD := poetry run 
- endif
-
+endif
 
 install: $(INSTALL_STAMP) ## install the project dependencies in a virtual environment
 $(INSTALL_STAMP): poetry.lock pyproject.toml 

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,6 +1,6 @@
-from app import config, webserver
-
-config.setup()
+# from app import config_simple as config
+from app import config_advanced as config
+from app import webserver
 
 print("Hello, world!")
 print(f"Example from config: {config.settings.example}")

--- a/app/config_advanced.py
+++ b/app/config_advanced.py
@@ -1,7 +1,7 @@
 """
-Module where you can access your configurations.
+Module where you can access your configurations, with delayed loading.
 
-To add more configurations, change the Settings classes and populate .env accordingly.
+There's a simpler version in config_simple.py.
 """
 
 
@@ -11,13 +11,6 @@ from loguru import logger
 from pydantic import BaseSettings
 
 settings: Settings
-"""
-Attribute with general settings.
-
-It requires invoking config.setup() before using.
-"""
-# this uses the prebound method pattern
-# further reading: https://python-patterns.guide/python/prebound-methods/
 
 
 class Settings(BaseSettings):

--- a/app/config_advanced.py
+++ b/app/config_advanced.py
@@ -7,7 +7,6 @@ There's a simpler version in config_simple.py.
 
 from __future__ import annotations
 
-from loguru import logger
 from pydantic import BaseSettings
 
 settings: Settings
@@ -30,5 +29,6 @@ def __getattr__(name):
         return _settings
     else:
         raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
 
 _settings: Settings | None = None

--- a/app/config_advanced.py
+++ b/app/config_advanced.py
@@ -20,31 +20,15 @@ class Settings(BaseSettings):
 def __getattr__(name):
     global _settings
 
-    # this will setup necessary config if someone tries to get the settings
-    # but hasn't set manually set up things
-    # it's useful to delay this, so we don't need to apply configurations when not needed, eg unit tests
+    # this will setup necessary config when someone tries to get the settings
+    # it's useful to delay this, so we don't need to apply configurations at import time
+    # eg tests may import modules without loading configuration from .env
     if name == "settings":
         if not _settings:
-            setup()
+            _settings = Settings()
 
         return _settings
     else:
         raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
-
-
-def setup():
-    global _settings
-    try:
-        _settings = Settings()
-    except Exception as e:
-        logger.error(e)
-        logger.error(
-            "This may have been caused by an empty or invalid .env file. Please see example.env for examples."
-        )
-        raise
-    logger.debug(
-        f"Populed settings based on environment variables: {_settings.__dict__}"
-    )
-
 
 _settings: Settings | None = None

--- a/app/config_simple.py
+++ b/app/config_simple.py
@@ -1,0 +1,20 @@
+"""
+Module where you can access your configurations.
+
+It does the job, so feel free to use it.
+
+But it's a bit more painful for testing.
+Meaning, settings are automatically loaded at import time,
+and other uses of the code such as testing will also need
+to set up environment variables.
+
+This is avoided in config_advanced.py.
+"""
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    example: str
+
+
+settings = Settings()

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,7 +1,13 @@
+"""
+Tests settings from config_advanced.py.
+
+Unlike config_simple, you may import the module without loading configuration.
+"""
+
 import pytest
 from pydantic import ValidationError
 
-from app.config import Settings
+from app.config_advanced import Settings
 
 
 def test_empty_settings():


### PR DESCRIPTION
The simple config is simpler: it has less code and doesn't use __getattr__, which is a complex Python feature.

But I prefer the advanced mode, which delays the loading of settings, allowing to import modules without setting up the configuration. This has been useful for testing without depending on configurations.
