### PR TITLE
fix: unpin python's patch version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -448,8 +448,8 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "3.10.5"
-content-hash = "26f210adb5f57acd8412260b1c39300a37a356c2ab0b63b93e86b10a17f55eca"
+python-versions = "3.10.*"
+content-hash = "5a42b8ef34ee197bc424d62886c5230896fb6e7f158cb6eae0f1b9a399a8385d"
 
 [metadata.files]
 astroid = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["duarte-pompeu <duarte-pompeu@users.noreply.github.com>"]
 
 [tool.poetry.dependencies]
-python = "3.10.5"
+python = "3.10.*"
 
 loguru = "0.6.0"
 pydantic = "1.9.1"


### PR DESCRIPTION
this should avoid errors in ci/cd, where patch versions can change